### PR TITLE
Proper VC++ exports

### DIFF
--- a/include/SLB/Hybrid.hpp
+++ b/include/SLB/Hybrid.hpp
@@ -49,11 +49,11 @@ namespace SLB {
 
   class HybridBase;
     
-  struct SLB_EXPORT InvalidMethod : public std::exception
+  struct InvalidMethod : public std::exception
   {  
-    InvalidMethod(const HybridBase*, const char *c);
-    ~InvalidMethod() throw() {}
-    const char* what() const throw() { return _what.c_str(); }
+    SLB_EXPORT InvalidMethod(const HybridBase*, const char *c);
+    SLB_EXPORT ~InvalidMethod() throw() {}
+    SLB_EXPORT const char* what() const throw() { return _what.c_str(); }
     std::string _what;
   };
 


### PR DESCRIPTION
Export the class members, not the class itself, when it derives from a non-exported type.
